### PR TITLE
     Add ha-parking-gent integration

### DIFF
--- a/_data/integrations/ha-parking-gent.yaml
+++ b/_data/integrations/ha-parking-gent.yaml
@@ -1,0 +1,5 @@
+   domain: ha_parking_gent
+   name: Parking Occupancy Ghent
+   documentations:
+     - name: GitHub
+       url: https://github.com/sebadv/ha-parking-gent


### PR DESCRIPTION
     This PR adds the Parking Occupancy Ghent integration to HACS default.

     The integration provides real-time parking occupancy information for parking facilities in Ghent, Belgium.

     Repository: https://github.com/sebadv/ha-parking-gent

     - [x] Publishing documentation read
     - [x] HACS action added and passing
     - [x] Link to action run: https://github.com/sebadv/ha-parking-gent/actions/runs/15240491544
     - [x] Link to current release: https://github.com/sebadv/ha-parking-gent/releases